### PR TITLE
fix: update workflow ref to @main

### DIFF
--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -9,13 +9,8 @@ on:
 jobs:
   ci-terraform:
     name: Continuous Integration for Terraform
-    uses: "benniemosher-dev/.github/.github/workflows/ci-terraform.yml@bam/add-terraform-workflow"
+    uses: "benniemosher-dev/.github/.github/workflows/ci-terraform.yml@main"
     secrets:
-      AWS_ACCOUNT_ID: ${{ secrets.QUEST_AWS_ACCOUNT_ID }}
-      KEYBASE_USERNAME: ${{ secrets.KEYBASE_USERNAME }}
-      KEYBASE_PAPERKEY: ${{ secrets.KEYBASE_PAPERKEY }}
       INFRACOST_API_KEY: ${{ secrets.INFRACOST_API_KEY }}
-      TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
     with:
       enable-cloudflare-tfvars: true
-      iam-role-name: "terraform-github-oidc"


### PR DESCRIPTION
## Summary
- Change workflow ref from `@bam/add-terraform-workflow` (non-existent branch) to `@main`
- Remove secrets not supported by reusable workflow (AWS_ACCOUNT_ID, KEYBASE_USERNAME, KEYBASE_PAPERKEY, TF_API_TOKEN)
- Remove unsupported input `iam-role-name`

## Test plan
- [ ] Verify CI passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)